### PR TITLE
Constructor TypeCasting

### DIFF
--- a/src/Support/Stringable.js
+++ b/src/Support/Stringable.js
@@ -14,7 +14,7 @@ export default class Stringable {
     constructor(value) {
         this.value = '';
         if(!this.emptyValues.includes(value)){
-            this.value = String(this.value)
+            this.value = String(value)
         }
     }
 

--- a/src/Support/Stringable.js
+++ b/src/Support/Stringable.js
@@ -12,7 +12,10 @@ export default class Stringable {
      * @param value
      */
     constructor(value) {
-        this.value = String(value + '');
+        this.value = '';
+        if(!this.emptyValues.includes(value)){
+            this.value = String(this.value)
+        }
     }
 
     /**
@@ -290,7 +293,15 @@ export default class Stringable {
      * @return {Boolean}
      */
     isEmpty() {
-        return ['', null, undefined].includes(this.value);
+        return this.emptyValues.includes(this.value);
+    }
+
+    /**
+     * Get Empty Values
+     * @return {string[]}
+     */
+    get emptyValues(){
+        return ['', null, undefined];
     }
 
     /**

--- a/tests/stringable.test.js
+++ b/tests/stringable.test.js
@@ -5,6 +5,12 @@ test('make instance of self', () => {
     expect(Stringable.of('Test')).toBeInstanceOf(Stringable)
 })
 
+test('undefined', () => {
+    expect(Stringable.of(undefined).toString()).toStrictEqual('')
+    expect(Stringable.of(null).toString()).toStrictEqual('')
+    expect(Stringable.of('').toString()).toStrictEqual('')
+})
+
 test('cast to string', () => {
     expect(('' + Stringable.of('Test'))).toEqual('Test')
 })


### PR DESCRIPTION
Insure types are cast correctly to prevent "undefined" and "null" cast to literal text.